### PR TITLE
Bump @types/react

### DIFF
--- a/template-ts/package.json
+++ b/template-ts/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@types/jest": "23.3.12",
     "@types/node": "10.12.18",
-    "@types/react": "16.8.8",
+    "@types/react": "16.8.16",
     "@types/react-dom": "16.8.0",
     "blueimp-md5": "2.3.0",
     "feed": "2.0.2",


### PR DESCRIPTION
I was having error related to `@types/react` after installing `create-react-blog --typescript`, and error went away after updating the package to the current newest version 

Before:
![image](https://user-images.githubusercontent.com/25751050/57192646-7b115d80-6f3b-11e9-898a-ed3e58e816c4.png)

After:
![image](https://user-images.githubusercontent.com/25751050/57192670-c461ad00-6f3b-11e9-9b1e-c0e34c5d2f26.png)

